### PR TITLE
84 xportr deep dive vignette

### DIFF
--- a/vignettes/deepdive.Rmd
+++ b/vignettes/deepdive.Rmd
@@ -205,7 +205,10 @@ datatable(
     autoWidth = TRUE
   )
 ) %>%
-  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold", lineHeight = "70%", textAlign = "center")
+  formatStyle(0,
+    target = "row", color = "black", backgroundColor = "white",
+    fontWeight = "bold", lineHeight = "70%", textAlign = "center"
+  )
 ```
 
 ## `xportr_type()`

--- a/vignettes/deepdive.Rmd
+++ b/vignettes/deepdive.Rmd
@@ -139,6 +139,28 @@ options(
 )
 ```
 
+## Are we being too verbose?
+
+One final note on `options()`.  4 of the core `{xportr}` functions have the ability to set messaging as `"none", "message", "warn", "stop"`. Setting each of these in all your calls can be a bit repetitive.  You can use `options()` to set these at a higher level and avoid this repitition.
+
+```{r, eval = FALSE}
+# Default
+options(
+    xportr.format_verbose = "none",
+    xportr.label_verbose = "none",
+    xportr.length_verbose = "none",
+    xportr.type_verbose = "none",
+)
+
+# Will send Warning Message to Console
+options(
+    xportr.format_verbose = "warn",
+    xportr.label_verbose = "warn",
+    xportr.length_verbose = "warn",
+    xportr.type_verbose = "warn",
+)
+```
+
 ## Going meta
 
 Each of the core `{xportr}` functions requires several inputs: A valid dataframe, a metadata object and a domain name, along with optional messaging. For example, here is a simple call using all of the functions. As you can see, a lot of information is repeated in each call.     

--- a/vignettes/xportr.Rmd
+++ b/vignettes/xportr.Rmd
@@ -39,20 +39,18 @@ local({
 
 
 ```{r, include=FALSE}
-
-knitr::knit_hooks$set(output = function(x, options){
-  if(!is.null(options$max_height)){
-    paste('<pre style = "max-height:', 
-          options$max_height, 
-          '; float: left; width: 775px; overflow-y: auto;">', 
-          x, "</pre>", 
-          sep = "")
-  } else{
+knitr::knit_hooks$set(output = function(x, options) {
+  if (!is.null(options$max_height)) {
+    paste('<pre style = "max-height:',
+      options$max_height,
+      '; float: left; width: 775px; overflow-y: auto;">',
+      x, "</pre>",
+      sep = ""
+    )
+  } else {
     x
   }
-  
 })
-
 ```
 
 # Getting Started with xportr
@@ -198,7 +196,7 @@ DT::datatable(adsl_order, options = list(
 Now we apply formats to the dataset.  These will typically be `DATE9.`, `DATETIME20` or `TIME5`, but many others can be used.  Notice that in the `ADSL` dataset there are 8 Date/Time variables and they are missing formats. Here we just take a peak at a few `TRT` variables, which have a `NULL` format.
 
 ```{r, max_height = "200px", echo = FALSE}
-adsl_fmt_pre <- adsl %>% 
+adsl_fmt_pre <- adsl %>%
   select(TRTSDT, TRTEDT, TRTSDTM, TRTEDTM)
 
 tribble(
@@ -206,9 +204,8 @@ tribble(
   "TRTSDT", attr(adsl_fmt_pre$TRTSDT, which = "format"),
   "TRTEDT", attr(adsl_fmt_pre$TRTEDT, which = "format"),
   "TRTSDTM", attr(adsl_fmt_pre$TRTSDTM, which = "format"),
-  "TRTEDTM",  attr(adsl_fmt_pre$TRTEDTM, which = "format")
-  )
-  
+  "TRTEDTM", attr(adsl_fmt_pre$TRTEDTM, which = "format")
+)
 ```
 
 Using our `xportr_format()` we can apply our formats to the dataset.
@@ -218,7 +215,7 @@ adsl_fmt <- adsl %>% xportr_format(var_spec, domain = "ADSL", "message")
 ```
 
 ```{r, max_height = "200px", echo = FALSE}
-adsl_fmt_post <- adsl_fmt %>% 
+adsl_fmt_post <- adsl_fmt %>%
   select(TRTSDT, TRTEDT, TRTSDTM, TRTEDTM)
 
 tribble(
@@ -226,9 +223,8 @@ tribble(
   "TRTSDT", attr(adsl_fmt_post$TRTSDT, which = "format"),
   "TRTEDT", attr(adsl_fmt_post$TRTEDT, which = "format"),
   "TRTSDTM", attr(adsl_fmt_post$TRTSDTM, which = "format"),
-  "TRTEDTM",  attr(adsl_fmt_post$TRTEDTM, which = "format")
-  )
-  
+  "TRTEDTM", attr(adsl_fmt_post$TRTEDTM, which = "format")
+)
 ```
 
 # xportr_label() 

--- a/vignettes/xportr.Rmd
+++ b/vignettes/xportr.Rmd
@@ -100,7 +100,7 @@ DT::datatable(adsl, options = list(
   autoWidth = FALSE, scrollX = TRUE, pageLength = 5,
   lengthMenu = c(5, 10, 15, 20)
 )) %>%
-  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold", lineHeight = "70%")
+  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold")
 ```
 
 **NOTE:** The `ADSL` dataset can be created by using this command `admiral::use_ad_template("adsl")`.
@@ -128,10 +128,14 @@ DT::datatable(var_spec_view, options = list(
   autoWidth = FALSE, scrollX = TRUE, pageLength = 5,
   lengthMenu = c(5, 10, 15, 20)
 )) %>%
-  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold", lineHeight = "70%")
+  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold")
 ```
 
 # xportr_type() 
+
+**NOTE:** We make use of `str()` to expose the attributes (length, labels, formats, type) 
+of the datasets. We have suppressed these calls for the sake of brevity.
+
 
 In order to be compliant with transport v5 specifications  an `xpt` file can only have two data types: character and numeric/dbl.  Currently the `ADSL` data set has chr, dbl, time, factor and date.
 
@@ -188,7 +192,7 @@ DT::datatable(adsl_order, options = list(
   autoWidth = FALSE, scrollX = TRUE, pageLength = 5,
   lengthMenu = c(5, 10, 15, 20)
 )) %>%
-  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold", lineHeight = "70%")
+  formatStyle(0, target = "row", color = "black", backgroundColor = "white", fontWeight = "bold")
 ```
 
 # xportr_format()
@@ -226,6 +230,9 @@ tribble(
   "TRTEDTM", attr(adsl_fmt_post$TRTEDTM, which = "format")
 )
 ```
+
+**NOTE:** You can use `attr(data$variable, which = "format")` to inspect formats applied 
+to a dataframe. The above output has these individual calls bound together for easier viewing.
 
 # xportr_label() 
 


### PR DESCRIPTION
### Thank you for your Pull Request! 

We have developed a Pull Request template to aid you and our reviewers.  Completing the below tasks helps to ensure our reviewers can maximize their time on your code as well as making sure the xportr codebase remains robust and consistent.  

### The scope of `{xportr}`

`{xportr}`'s scope is to enable R users to write out submission compliant `xpt` files that can be delivered to a Health Authority or to downstream validation software programs.  We see labels, lengths, types, ordering and formats from a dataset specification object (SDTM and ADaM) as being our primary focus. We also see messaging and warnings to users around applying information from the specification file as a primary focus. Please make sure your Pull Request meets this **scope of {xportr}**. If your Pull Request moves beyond this scope, please get in touch with the `{xportr}` team on [slack](https://pharmaverse.slack.com/archives/C030EB2M4GM) or create an issue to discuss.

Please check off each task box as an acknowledgment that you completed the task. This checklist is part of the Github Action workflows and the Pull Request will not be merged into the `devel` branch until you have checked off each task.

### Changes Description

_(descriptions of changes)_ 

### Task List

- [ ] The spirit of xportr is met in your Pull Request
- [ ] Place Closes #<insert_issue_number> into the beginning of your Pull Request Title (Use Edit button in top-right if you need to update)
- [ ] Summary of changes filled out in the above Changes Description.  Can be removed or left blank if changes are minor/self-explanatory.
- [ ] Check that your Pull Request is targeting the `devel` branch, Pull Requests to `main` should use the [Release Pull Request Template](https://github.com/atorus-research/xportr/tree/94_pr_template/.github/PULL_REQUEST_TEMPLATE)
- [ ] Code is formatted according to the [tidyverse style guide](https://style.tidyverse.org/).  Use `styler` package and functions to style files accordingly.
- [ ] Updated relevant unit tests or have written new unit tests. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Unit-Tests) for conventions used in this package.
- [ ] Creation/updated relevant roxygen headers and examples. See our [Wiki](https://github.com/atorus-research/xportr/wiki/Style-Guide-for-Roxygen-Headers) for conventions used in this package.
- [ ] Run `devtools::document()` so all `.Rd` files in the `man` folder and the `NAMESPACE` file in the project root are updated appropriately
- [ ] Run `pkgdown::build_site()` and check that all affected examples are displayed correctly and that all new/updated functions occur on the "Reference" page.
- [ ] Update NEWS.md if the changes pertain to a user-facing function (i.e. it has an @export tag) or documentation aimed at users (rather than developers)
- [ ] Address any updates needed for vignettes and/or templates
- [ ] Link the issue Development Panel so that it closes after successful merging.
- [ ] Fix merge conflicts 
- [ ] Pat yourself on the back for a job well done!  Much love to your accomplishment!
